### PR TITLE
Responsive CSS tweaks

### DIFF
--- a/style.css
+++ b/style.css
@@ -62,6 +62,7 @@ h1,h2,h3,h4 { margin-bottom: 1vh;}
     flex-direction: row;
     justify-content: center;
     align-items: center;
+    flex-wrap: wrap;
 }
 
 div .flexRow button, div .flexRow a {
@@ -171,7 +172,6 @@ div .flexRow button, div .flexRow a {
 
 #mainHeader {
     width: 100%;
-    height: 7vh;
     background-color: var(--header-color);
     color:black;
 }


### PR DESCRIPTION
or: _Make your entire game responsive with this one weird trick_

(Hi, we had an exchange on Reddit about a week ago)

- Add `flex-wrap: wrap` to `.flexRow`: wrap most rows of things on narrow screens
- Remove `height` from `#mainHeader`: header elements could extend below the header itself on low-height viewports

Before:

![image](https://github.com/MrBacon470/Coop-Co/assets/121909/8dececa5-a3ad-475c-a959-a37996c8ce54)

After:

<img width="506" alt="image" src="https://github.com/MrBacon470/Coop-Co/assets/121909/652c65aa-5a9f-403d-b333-d588da242d44">
